### PR TITLE
feat(mac-linux.sh): add support for fish shell configuration

### DIFF
--- a/install/mac-linux.sh
+++ b/install/mac-linux.sh
@@ -35,8 +35,11 @@ if [[ "$SHELL" =~ "zsh" ]]; then
     CONFIG_FILE="$HOME/.zshrc"
 elif [[ "$SHELL" =~ "bash" ]]; then
     CONFIG_FILE="$HOME/.bashrc"
+elif [[ "$SHELL" =~ "fish" ]]; then
+    mkdir -p $HOME/.config/fish
+    CONFIG_FILE="$HOME/.config/fish/config.fish"
 else
-    echo "Unsupported shell. Only zsh and bash are supported."
+    echo "Unsupported shell. Only zsh, bash and fish are supported."
     exit 1
 fi
 


### PR DESCRIPTION
Протестил локально, строчки добавились
```bash
# Add dodocli to PATH
export PATH="/home/egorrko/dodocli:$PATH"
```
и `dodo` в терминале корректно заработал